### PR TITLE
chore: bump tar 7.5.10 to 7.5.13 (security fix)

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "packages/templates/*"
   ],
   "resolutions": {
-    "tar": "^7.5.10",
+    "tar": "^7.5.13",
     "svgo": "^3.3.3",
     "serialize-javascript": "^6.0.2",
     "koa": "^3.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1780,6 +1780,26 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@clippyjs/source@workspace:.":
+  version: 0.0.0-use.local
+  resolution: "@clippyjs/source@workspace:."
+  dependencies:
+    "@nx/eslint": "npm:^22.0.3"
+    "@nx/js": "npm:^22.0.3"
+    "@nx/playwright": "npm:^22.0.3"
+    "@nx/react": "npm:^22.0.3"
+    "@nx/rollup": "npm:^22.0.3"
+    "@nx/vite": "npm:^22.0.3"
+    "@nx/vitest": "npm:^22.5.4"
+    "@playwright/test": "npm:^1.58.2"
+    eslint: "npm:^9.39.1"
+    nx: "npm:22.0.3"
+    typescript: "npm:^5.7.3"
+    vite: "npm:^7.2.2"
+    vitest: "npm:^4.0.8"
+  languageName: unknown
+  linkType: soft
+
 "@clippyjs/storybook@workspace:packages/storybook":
   version: 0.0.0-use.local
   resolution: "@clippyjs/storybook@workspace:packages/storybook"
@@ -7620,26 +7640,6 @@ __metadata:
     react-dom: "npm:^19.0.0"
     typescript: "npm:~5.7.3"
     vite: "npm:^6.0.11"
-  languageName: unknown
-  linkType: soft
-
-"clippyjs-workspace@workspace:.":
-  version: 0.0.0-use.local
-  resolution: "clippyjs-workspace@workspace:."
-  dependencies:
-    "@nx/eslint": "npm:^22.0.3"
-    "@nx/js": "npm:^22.0.3"
-    "@nx/playwright": "npm:^22.0.3"
-    "@nx/react": "npm:^22.0.3"
-    "@nx/rollup": "npm:^22.0.3"
-    "@nx/vite": "npm:^22.0.3"
-    "@nx/vitest": "npm:^22.5.4"
-    "@playwright/test": "npm:^1.58.2"
-    eslint: "npm:^9.39.1"
-    nx: "npm:22.0.3"
-    typescript: "npm:^5.7.3"
-    vite: "npm:^7.2.2"
-    vitest: "npm:^4.0.8"
   languageName: unknown
   linkType: soft
 
@@ -15485,16 +15485,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:^7.5.10":
-  version: 7.5.10
-  resolution: "tar@npm:7.5.10"
+"tar@npm:^7.5.13":
+  version: 7.5.13
+  resolution: "tar@npm:7.5.13"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10c0/ed905e4b33886377df6e9206e5d1bd34458c21666e27943f946799416f86348c938590d573d6a69312cb29c583b122647a64ec92782f2b7e24e68d985dd72531
+  checksum: 10c0/5c65b8084799bde7a791593a1c1a45d3d6ee98182e3700b24c247b7b8f8654df4191642abbdb07ff25043d45dcff35620827c3997b88ae6c12040f64bed5076b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Bumps `tar` from 7.5.10 to 7.5.13 in resolutions and yarn.lock
- Fixes symlink escaping vulnerability (CVE in node-tar)
- Replaces the overly aggressive dependabot PR #42 which tried to bump vite 5→8

## Security Fix
- Prevents raced symlink writes outside cwd
- Prevents escaping symlinks with drive-relative paths

## Test Plan
- [x] `yarn install` succeeds
- [ ] CI checks pass